### PR TITLE
Initialize Track FX correctly

### DIFF
--- a/__tests__/Tracks.ts
+++ b/__tests__/Tracks.ts
@@ -9,6 +9,15 @@ test('has correct number of fx', () => {
   expect(track.fx.length).toBe(expected);
 });
 
+test('fx are initialized with correct track and fx number', () => {
+  const track = new Track(9, 4, () => null);
+
+  track.fx.forEach((fx, index) => {
+    expect(fx.trackNumber).toBe(track.trackNumber);
+    expect(fx.fxNumber).toBe(index + 1);
+  });
+});
+
 test('has correct track number', () => {
   const expected = 9874;
 

--- a/src/Reaper.ts
+++ b/src/Reaper.ts
@@ -2,7 +2,7 @@
  * Contains classes for controlling Reaper via OSC
  * @module
  */
-import {ActionMessage, OscArgument, OscMessage} from './Messages';
+import {ActionMessage, OscMessage} from './Messages';
 import {Track} from './Tracks';
 import {Transport} from './Transport';
 import * as osc from 'osc';

--- a/src/Tracks.ts
+++ b/src/Tracks.ts
@@ -65,7 +65,7 @@ export class Track implements INotifyPropertyChanged {
     this._sendOscMessage = sendOscMessage;
 
     for (let i = 0; i < numberOfFx; i++) {
-      this._fx[i] = new TrackFx(i + 1, i, sendOscMessage);
+      this._fx[i] = new TrackFx(trackNumber, i + 1, sendOscMessage);
     }
 
     this.initHandlers();


### PR DESCRIPTION
Fixes #12

The track/fx number of Track FX were not being set correctly when initializing a track. Added unit test for this case.